### PR TITLE
Modifications by Glen Walker

### DIFF
--- a/bsnmp/snmp.c
+++ b/bsnmp/snmp.c
@@ -657,7 +657,7 @@ snmp_pdu_encode(struct snmp_pdu *pdu, struct asn_buf *resp_b)
 		return (err);
 	for (idx = 0; idx < pdu->nbindings; idx++)
 		if ((err = snmp_binding_encode(resp_b, &pdu->bindings[idx]))
-		    != ASN_ERR_OK)
+		    != SNMP_CODE_OK)
 			return (SNMP_CODE_FAILED);
 
 	return (snmp_fix_encoding(resp_b, pdu));

--- a/common/async-resolver.c
+++ b/common/async-resolver.c
@@ -78,6 +78,8 @@ static void
 tsignal_clear(int* sig)
 {
     char buf[16];
+    if(sig[0] == -1)
+        return;
     while(read(sig[0], buf, sizeof(buf)) > 0);
 }
 
@@ -308,9 +310,7 @@ async_resolver_queue(const char* hostname, const char* servname,
         }
         else
         {
-            r = res_requests;
-            while(r->next)
-                r = r->next;
+            for(r = res_requests; r->next; r = r->next);
             r->next = req;
         }
 

--- a/common/compat.h
+++ b/common/compat.h
@@ -89,4 +89,20 @@ void strlwr(char* data);
 void strupr(char* data);
 #endif
 
+/*
+ * strcasestr is a GNU specific extension to the C standard, gcc -Wall will
+ * misleadingly warn "implicit declaration of function" unless we provide a
+ * function prototype ourselves.
+ * http://cboard.cprogramming.com/c-programming/116834-question-linux-gcc-c-standards.html
+ */
+char * strcasestr(const char *s, const char *find);
+
+#ifndef HAVE_STRNCASECMP
+int strncasecmp(const char *s1, const char *s2, size_t n);
+#endif
+
+#ifndef HAVE_DAEMON
+int daemon(int nochdir, int noclose);
+#endif
+
 #endif /* __COMPAT_H__ */

--- a/common/server-mainloop.c
+++ b/common/server-mainloop.c
@@ -409,6 +409,7 @@ void
 server_unwatch(int fd)
 {
     socket_callback* cb;
+    socket_callback* next;
 
     ASSERT(fd != -1);
 
@@ -422,19 +423,26 @@ server_unwatch(int fd)
     if(ctx.callbacks->fd == fd)
     {
         cb = ctx.callbacks;
-        ctx.callbacks = cb->next;
+        ctx.callbacks = ctx.callbacks->next;
         free(cb);
-        return;
     }
 
+    if(!ctx.callbacks)
+        return;
+
     /* One ahead processing of rest */
-    for(cb = ctx.callbacks; cb->next; cb = cb->next)
+    cb = ctx.callbacks;
+    while(cb->next)
     {
         if(cb->next->fd == fd)
         {
+            next = cb->next;
             cb->next = cb->next->next;
-            free(cb->next);
-            return;
+            free(next);
+        }
+        else
+        {
+            cb = cb->next;
         }
     }
 }

--- a/common/usuals.h
+++ b/common/usuals.h
@@ -49,6 +49,9 @@
 #include <errno.h>
 #include <string.h>
 
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
 #include "compat.h"
 
 #ifndef NULL

--- a/daemon/config.c
+++ b/daemon/config.c
@@ -78,6 +78,7 @@ config_ctx;
 #define CONFIG_INTERVAL "interval"
 #define CONFIG_TIMEOUT "timeout"
 #define CONFIG_SOURCE "source"
+#define CONFIG_REFERENCE "reference"
 
 #define CONFIG_SNMP "snmp"
 #define CONFIG_SNMP2 "snmp2"
@@ -321,6 +322,22 @@ parse_item (const char *field, char *uri, config_ctx *ctx)
 	return item;
 }
 
+static rb_item*
+parse_item_reference (const char *field, char *reference, config_ctx *ctx)
+{
+    rb_item *item;
+
+    for(item = ctx->items; item; item = item->next) {
+        if(strcmp(field, item->field) == 0) {
+            item->reference = reference;
+            return item;
+        }
+    }
+
+    log_warnx ("%s: field %s not found", ctx->confname, field);
+    return NULL;
+}
+
 static void
 config_value(const char* header, const char* name, char* value,
              config_ctx* ctx)
@@ -396,7 +413,7 @@ config_value(const char* header, const char* name, char* value,
     *suffix = 0;
     suffix++;
 
-    /* If it starts with "field." */
+    /* If it starts with "field.source" */
     if(strcmp(suffix, CONFIG_SOURCE) == 0)
     {
         const char* t;
@@ -409,6 +426,13 @@ config_value(const char* header, const char* name, char* value,
 
         /* Parse out the field */
         parse_item(name, value, ctx);
+    }
+
+    /* If it starts with "field.reference" */
+    if(strcmp(suffix, CONFIG_REFERENCE) == 0)
+    {
+        /* Parse out the field */
+        parse_item_reference(name, value, ctx);
     }
 }
 

--- a/daemon/rrdbotd.c
+++ b/daemon/rrdbotd.c
@@ -325,7 +325,7 @@ main(int argc, char* argv[])
     mib_uninit();
 
     /* Rev up the main engine */
-    snmp_engine_init (local, 3);
+    snmp_engine_init (local, g_state.retries);
     rb_poll_engine_init();
 
     free (local);

--- a/daemon/rrdbotd.h
+++ b/daemon/rrdbotd.h
@@ -65,6 +65,9 @@ typedef struct _rb_item
     /* The field name, RRD and display */
     const char* field;
 
+    /* The reference value for the field */
+    const char* reference;
+
     /* Connection information */
     const char* community;
     int version;
@@ -88,6 +91,10 @@ typedef struct _rb_item
     int query_searched;
     struct asn_oid query_last;
     int query_request;
+
+    /* Book keeping */
+    mstime last_request;
+    mstime last_polled;
 
     /* The last value / current request */
     union

--- a/mib/parse.c
+++ b/mib/parse.c
@@ -3666,7 +3666,6 @@ read_module_internal(const char *name)
 {
     struct module  *mp;
     FILE           *fp;
-    struct node    *np;
 
     init_mib_internals();
 
@@ -3692,7 +3691,7 @@ read_module_internal(const char *name)
             /*
              * Parse the file
              */
-            np = parse(fp, NULL);
+            parse(fp, NULL);
             fclose(fp);
             File = oldFile;
             mibLine = oldLine;

--- a/tools/rrdbot-create.c
+++ b/tools/rrdbot-create.c
@@ -246,14 +246,14 @@ static int
 mkdir_p(char* path)
 {
     struct stat sb;
-    int first, last, retval = 0;
+    int last, retval = 0;
     char* p = path;
 
     /* Skip leading '/'. */
     while(p[0] == '/')
         ++p;
 
-    for(first = 1, last = 0; !last ; ++p)
+    for(last = 0; !last ; ++p)
     {
         if(p[0] == '\0')
             last = 1;

--- a/tools/rrdbot-get.c
+++ b/tools/rrdbot-get.c
@@ -229,7 +229,7 @@ print_result (struct snmp_value* value)
 		printf ("%u\n", value->v.uint32);
 		break;
 	case SNMP_SYNTAX_COUNTER64:
-		printf ("%llu\n", value->v.counter64);
+		printf ("%" PRIu64 "\n", value->v.counter64);
 		break;
 	case SNMP_SYNTAX_OCTETSTRING:
 		t = xcalloc (value->v.octetstring.len + 1);


### PR DESCRIPTION
- Raw file format modified - now one sample per line, and a reference field introduced to the configuration
  Line format now tab-separated timestamp, reference, value
- Memory leaks fixed, runs cleanly under valgrind
- Compiles without warnings on Ubuntu 12.04
- No longer sends duplicate requests for values in the same SNMP PDU (e.g. a request for ifDescr was included once per poll item that includes an ifDescr query, even if identical to a request already in the PDU)
- rrdbotd now respects --retries command line parameter
- Reports actual error message for errors opening raw files
