### PR TITLE
meltdown countermeasure mitigation

### DIFF
--- a/daemon/rrd-update.c
+++ b/daemon/rrd-update.c
@@ -251,7 +251,7 @@ void rb_rrd_update(rb_poller *poll)
             }
             free(parent);
 
-            fd = open(path, O_WRONLY|O_APPEND|O_CREAT);
+            fd = open(path, O_WRONLY|O_APPEND|O_CREAT, 0644);
             if(fd == -1) {
                 log_errorx("open raw file for append failed: %s: %s", path, strerror(errno));
                 break; /* next raw file */
@@ -270,6 +270,7 @@ static void
 write_sample(int fd, const char* path, const time_t *time, const rb_item *item)
 {
 	char buf[RAW_BUFLEN];
+	ssize_t nw;
 	int n;
 
 	switch (item->vtype) {
@@ -308,7 +309,7 @@ write_sample(int fd, const char* path, const time_t *time, const rb_item *item)
 		return;
 	}
 
-	if (write(fd, buf, strlen(buf)) == -1) {
+	if ((nw = write(fd, buf, n)) == -1 || nw != n) {
 		log_errorx("write to raw file failed: %s: %s", path, strerror(errno));
 		return;
 	}

--- a/daemon/rrd-update.c
+++ b/daemon/rrd-update.c
@@ -232,8 +232,7 @@ void rb_rrd_update(rb_poller *poll)
 
             if(len == 0)
             {
-                log_errorx("couldn't strftime the raw file path: %s for writting : %s",
-                            rawpath->path, strerror(errno));
+                log_errorx("raw file: %s: strftime: %s", rawpath->path, strerror(errno));
                 break; /* next raw file */
             }
 
@@ -244,8 +243,7 @@ void rb_rrd_update(rb_poller *poll)
                 return;
             if((mkdir_p(parent, 0777) == -1) && (errno != EEXIST))
             {
-                log_errorx("couldn't create directory for raw file: %s : %s",
-                            path,  strerror(errno));
+                log_errorx("raw file: %s: mkdir: %s", path, strerror(errno));
                 free(parent);
                 break; /* next raw file */
             }
@@ -253,14 +251,14 @@ void rb_rrd_update(rb_poller *poll)
 
             fd = open(path, O_WRONLY|O_APPEND|O_CREAT, 0644);
             if(fd == -1) {
-                log_errorx("open raw file for append failed: %s: %s", path, strerror(errno));
+                log_errorx("raw file: %s: open: %s", path, strerror(errno));
                 break; /* next raw file */
             }
 
 	    write_sample(fd, path, &time, item);
 
 	    if (close(fd) == -1) {
-		    log_errorx("close of raw file failed: %s: %s", path, strerror(errno));
+		    log_errorx("raw file: %s: close: %s", path, strerror(errno));
 	    }
         }
     }
@@ -310,7 +308,7 @@ write_sample(int fd, const char* path, const time_t *time, const rb_item *item)
 	}
 
 	if ((nw = write(fd, buf, n)) == -1 || nw != n) {
-		log_errorx("write to raw file failed: %s: %s", path, strerror(errno));
+		log_errorx("raw file: %s: write: %s", path, strerror(errno));
 		return;
 	}
 }

--- a/daemon/rrd-update.c
+++ b/daemon/rrd-update.c
@@ -289,7 +289,7 @@ write_sample(int fd, const char* path, const time_t *time, const rb_item *item)
 		break;
 
 	case VALUE_UNSET:
-		n = snprintf(buf, sizeof(buf), "%"PRId64"\t%s\n",
+		n = snprintf(buf, sizeof(buf), "%"PRId64"\t%s\t\n",
 		    *time,
 		    (item->reference ? item->reference : item->field));
 		break;

--- a/daemon/rrd-update.c
+++ b/daemon/rrd-update.c
@@ -250,16 +250,18 @@ void rb_rrd_update(rb_poller *poll)
             free(parent);
 
             fd = open(path, O_WRONLY|O_APPEND|O_CREAT, 0644);
-            if(fd == -1) {
+            if(fd == -1)
+            {
                 log_errorx("raw file: %s: open: %s", path, strerror(errno));
                 break; /* next raw file */
             }
 
-	    write_sample(fd, path, &time, item);
+            write_sample(fd, path, &time, item);
 
-	    if (close(fd) == -1) {
-		    log_errorx("raw file: %s: close: %s", path, strerror(errno));
-	    }
+            if (close(fd) == -1)
+            {
+                log_errorx("raw file: %s: close: %s", path, strerror(errno));
+            }
         }
     }
 }
@@ -267,48 +269,48 @@ void rb_rrd_update(rb_poller *poll)
 static void
 write_sample(int fd, const char* path, const time_t *time, const rb_item *item)
 {
-	char buf[RAW_BUFLEN];
-	ssize_t nw;
-	int n;
+    char buf[RAW_BUFLEN];
+    ssize_t nw;
+    int n;
 
-	switch (item->vtype) {
-	case VALUE_REAL:
-		n = snprintf(buf, sizeof(buf), "%"PRId64"\t%s\t%"PRId64"\n",
-		    *time,
-		    (item->reference ? item->reference : item->field),
-		    item->v.i_value);
-		break;
+    switch (item->vtype) {
+    case VALUE_REAL:
+        n = snprintf(buf, sizeof(buf), "%"PRId64"\t%s\t%"PRId64"\n",
+          *time,
+          (item->reference ? item->reference : item->field),
+          item->v.i_value);
+        break;
 
-	case VALUE_FLOAT:
-		n = snprintf(buf, sizeof(buf), "%"PRId64"\t%s\t%.4lf\n",
-		    *time,
-		    (item->reference ? item->reference : item->field),
-		    item->v.f_value);
-		break;
+    case VALUE_FLOAT:
+        n = snprintf(buf, sizeof(buf), "%"PRId64"\t%s\t%.4lf\n",
+          *time,
+          (item->reference ? item->reference : item->field),
+          item->v.f_value);
+        break;
 
-	case VALUE_UNSET:
-		n = snprintf(buf, sizeof(buf), "%"PRId64"\t%s\t\n",
-		    *time,
-		    (item->reference ? item->reference : item->field));
-		break;
+    case VALUE_UNSET:
+        n = snprintf(buf, sizeof(buf), "%"PRId64"\t%s\t\n",
+          *time,
+          (item->reference ? item->reference : item->field));
+        break;
 
-	default:
-		log_errorx("raw file: %s: unknown sample value type: %d", path, item->vtype);
-		return;
-	}
+    default:
+        log_errorx("raw file: %s: unknown sample value type: %d", path, item->vtype);
+        return;
+    }
 
-	if (n == -1) {
-		log_errorx("raw file: %s: snprintf: %s", path, strerror(errno));
-		return;
-	}
+    if (n == -1) {
+        log_errorx("raw file: %s: snprintf: %s", path, strerror(errno));
+        return;
+    }
 
-	if (n >= sizeof(buf)) {
-		log_errorx("raw file: %s: truncated sample string: required: %d", path, n);
-		return;
-	}
+    if (n >= sizeof(buf)) {
+        log_errorx("raw file: %s: truncated sample string: required: %d", path, n);
+        return;
+    }
 
-	if ((nw = write(fd, buf, n)) == -1 || nw != n) {
-		log_errorx("raw file: %s: write: %s", path, strerror(errno));
-		return;
-	}
+    if ((nw = write(fd, buf, n)) == -1 || nw != n) {
+        log_errorx("raw file: %s: write: %s", path, strerror(errno));
+        return;
+    }
 }


### PR DESCRIPTION
write raw files with syscalls not stdio; reduces per sample syscalls from 47 to 33 as a precaution against performance impacts from the Meltdown countermeasures (CVE-2017-5754). this also guarantees write atomicity, enabling multiple rrdbotd processes to safely write to the one raw file.