### PR TITLE
remove mkdir -p for every RAW record written 

### DIFF
--- a/daemon/rrd-update.c
+++ b/daemon/rrd-update.c
@@ -151,7 +151,6 @@ void rb_rrd_update(rb_poller *poll)
     for(rawpath = poll->rawlist; rawpath; rawpath = rawpath->next) {
         for(item = poll->items; item; item = item->next) {
             char path[MAXPATHLEN];
-            char *parent = NULL;
             int fd;
             struct tm *timeinfo;
             time_t time;


### PR DESCRIPTION
Making the RAW file directory on every RAW record is gratuitous. Our directory names are not a function of time and if the directory does not exist the open(2) call will soon tell us. Removes a few more syscalls, too.