### PR TITLE
Timers

### DIFF
--- a/common/server-mainloop.c
+++ b/common/server-mainloop.c
@@ -462,6 +462,12 @@ server_timer(int ms, server_timer_callback callback, void* arg)
 }
 
 int
+server_timer_at(struct timeval at, int ms, server_timer_callback callback, void* arg)
+{
+    return add_timer(at, ms, 0, callback, arg);
+}
+
+int
 server_oneshot(int ms, server_timer_callback callback, void* arg)
 {
     struct timeval interval;

--- a/common/server-mainloop.c
+++ b/common/server-mainloop.c
@@ -134,12 +134,12 @@ timeval_compare(struct timeval* t1, struct timeval* t2)
     (fprintf(stderr, "{ %d:%d }", (uint)((tv).tv_sec), (uint)((tv).tv_usec / 1000)))
 
 static int
-add_timer(struct timeval at, int ms, int oneshot, server_timer_callback callback, void* arg)
+add_timer(struct timeval at, int ms, server_timer_callback callback, void* arg)
 {
     struct timeval interval;
     timer_callback* cb;
 
-    ASSERT (ms || oneshot);
+    ASSERT (ms);
     ASSERT(callback != NULL);
 
     interval.tv_sec = ms / 1000;
@@ -153,11 +153,7 @@ add_timer(struct timeval at, int ms, int oneshot, server_timer_callback callback
     }
 
     memcpy(&(cb->at), &at, sizeof(cb->at));
-
-    if (oneshot)
-        memset(&(cb->interval), 0, sizeof(cb->interval));
-    else
-        memcpy(&(cb->interval), &interval, sizeof(cb->interval));
+    memcpy(&(cb->interval), &interval, sizeof(cb->interval));
 
     cb->callback = callback;
     cb->arg = arg;
@@ -458,30 +454,11 @@ server_timer(int ms, server_timer_callback callback, void* arg)
     at = now;
     timeval_add(&at, &interval);
 
-    return add_timer(at, ms, 0, callback, arg);
+    return add_timer(at, ms, callback, arg);
 }
 
 int
 server_timer_at(struct timeval at, int ms, server_timer_callback callback, void* arg)
 {
-    return add_timer(at, ms, 0, callback, arg);
-}
-
-int
-server_oneshot(int ms, server_timer_callback callback, void* arg)
-{
-    struct timeval interval;
-    struct timeval at;
-    struct timeval now;
-    if (gettimeofday(&now, NULL) == -1) {
-	err(1, "gettimeofday failed");
-    }
-
-    interval.tv_sec = ms / 1000;
-    interval.tv_usec = (ms % 1000) * 1000; /* into micro seconds */
-
-    at = now;
-    timeval_add(&at, &interval);
-
-    return add_timer(at, ms, 1, callback, arg);
+    return add_timer(at, ms, callback, arg);
 }

--- a/common/server-mainloop.c
+++ b/common/server-mainloop.c
@@ -77,16 +77,16 @@ server_context;
 static server_context ctx;
 
 static int
-add_timer(struct timeval at, int ms, server_timer_callback callback, void* arg)
+add_timer(struct timeval at, int period_ms, server_timer_callback callback, void* arg)
 {
     struct timeval interval;
     timer_callback* cb;
 
-    ASSERT (ms);
+    ASSERT (period_ms);
     ASSERT(callback != NULL);
 
-    interval.tv_sec = ms / 1000;
-    interval.tv_usec = (ms % 1000) * 1000; /* into micro seconds */
+    interval.tv_sec = period_ms / 1000;
+    interval.tv_usec = (period_ms % 1000) * 1000; /* into micro seconds */
 
     cb = (timer_callback*)calloc(1, sizeof(*cb));
     if(!cb)
@@ -378,7 +378,7 @@ server_unwatch(int fd)
 }
 
 int
-server_timer(int ms, server_timer_callback callback, void* arg)
+server_timer(int period_ms, server_timer_callback callback, void* arg)
 {
     struct timeval interval;
     struct timeval at;
@@ -387,17 +387,17 @@ server_timer(int ms, server_timer_callback callback, void* arg)
 	err(1, "gettimeofday failed");
     }
 
-    interval.tv_sec = ms / 1000;
-    interval.tv_usec = (ms % 1000) * 1000; /* into micro seconds */
+    interval.tv_sec = period_ms / 1000;
+    interval.tv_usec = (period_ms % 1000) * 1000; /* into micro seconds */
 
     at = now;
     timeradd(&at, &interval, &at);
 
-    return add_timer(at, ms, callback, arg);
+    return add_timer(at, period_ms, callback, arg);
 }
 
 int
-server_timer_at(struct timeval at, int ms, server_timer_callback callback, void* arg)
+server_timer_at(struct timeval at, int period_ms, server_timer_callback callback, void* arg)
 {
-    return add_timer(at, ms, callback, arg);
+    return add_timer(at, period_ms, callback, arg);
 }

--- a/common/server-mainloop.c
+++ b/common/server-mainloop.c
@@ -82,11 +82,18 @@ add_timer(struct timeval at, int period_ms, server_timer_callback callback, void
     struct timeval interval;
     timer_callback* cb;
 
-    ASSERT (period_ms);
+    ASSERT(period_ms >= 0);
     ASSERT(callback != NULL);
 
-    interval.tv_sec = period_ms / 1000;
-    interval.tv_usec = (period_ms % 1000) * 1000; /* into micro seconds */
+    if (period_ms == 0)
+    {
+	timerclear(&interval); /* one-shot */
+    }
+    else
+    {
+	interval.tv_sec = period_ms / 1000;
+	interval.tv_usec = (period_ms % 1000) * 1000; /* into micro seconds */
+    }
 
     cb = (timer_callback*)calloc(1, sizeof(*cb));
     if(!cb)
@@ -234,10 +241,8 @@ server_run()
                     if(timercmp(&(timcb->at), &current, <=))
                         memcpy(&(timcb->at), &current, sizeof(timcb->at));
                 }
-
-                /* Otherwise remove it. Either one shot, or returned 0 */
-                else
-                {
+		else
+		{
                     timcb = remove_timer(timcb);
                     continue;
                 }

--- a/common/server-mainloop.c
+++ b/common/server-mainloop.c
@@ -95,8 +95,8 @@ add_timer(struct timeval at, int ms, server_timer_callback callback, void* arg)
         return -1;
     }
 
-    memcpy(&(cb->at), &at, sizeof(cb->at));
-    memcpy(&(cb->interval), &interval, sizeof(cb->interval));
+    memcpy(&cb->at, &at, sizeof(cb->at));
+    memcpy(&cb->interval, &interval, sizeof(cb->interval));
 
     cb->callback = callback;
     cb->arg = arg;

--- a/common/server-mainloop.h
+++ b/common/server-mainloop.h
@@ -50,7 +50,6 @@ int     server_stopped();
 int     server_watch(int fd, int type, server_socket_callback callback, void* arg);
 void    server_unwatch(int fd);
 int     server_timer(int length, server_timer_callback callback, void* arg);
-int     server_oneshot(int length, server_timer_callback callback, void* arg);
 int     server_timer_from(struct timeval, int, server_timer_callback, void*);
 uint64_t server_get_time();
 

--- a/common/server-mainloop.h
+++ b/common/server-mainloop.h
@@ -51,6 +51,7 @@ int     server_watch(int fd, int type, server_socket_callback callback, void* ar
 void    server_unwatch(int fd);
 int     server_timer(int length, server_timer_callback callback, void* arg);
 int     server_oneshot(int length, server_timer_callback callback, void* arg);
+int     server_timer_from(struct timeval, int, server_timer_callback, void*);
 uint64_t server_get_time();
 
 #endif /* __SERVER_MAINLOOP_H__ */

--- a/common/server-mainloop.h
+++ b/common/server-mainloop.h
@@ -50,7 +50,7 @@ int     server_stopped();
 int     server_watch(int fd, int type, server_socket_callback callback, void* arg);
 void    server_unwatch(int fd);
 int     server_timer(int length, server_timer_callback callback, void* arg);
-int     server_timer_from(struct timeval, int, server_timer_callback, void*);
+int     server_timer_at(struct timeval, int, server_timer_callback, void*);
 uint64_t server_get_time();
 
 #endif /* __SERVER_MAINLOOP_H__ */

--- a/common/snmp-engine.c
+++ b/common/snmp-engine.c
@@ -835,7 +835,7 @@ request_flush_cb (mstime when, void *arg)
 {
 	snmp_flush_pending = 0;
 	request_flush_all (when);
-	return 0;
+	return 0; // unrepeated
 }
 
 static struct request*
@@ -976,7 +976,7 @@ snmp_engine_request (const char *hostname, const char *port,
 
 	/* Otherwise flush on the idle callback */
 	else if (!snmp_flush_pending) {
-		server_oneshot (0, request_flush_cb, NULL);
+		server_timer (0, request_flush_cb, NULL);
 		snmp_flush_pending = 1;
 	}
 


### PR DESCRIPTION
make poller timer initialisation robust against late wakeups breaking the distribution of pollers across the poll interval. Also ensures all pollers are started relative to a constant timestamp.